### PR TITLE
Fix opening files in iPad

### DIFF
--- a/ios/RNFileOpener/RNFileOpener.m
+++ b/ios/RNFileOpener/RNFileOpener.m
@@ -11,7 +11,7 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMine fromRect:(CGRectMake)rect
+RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMine
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -34,7 +34,7 @@ RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMi
         
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
     {
-        wasOpened = [self.FileOpener presentOptionsMenuFromRect:rect inView:ctrl.view animated:YES];
+        wasOpened = [self.FileOpener presentOptionsMenuFromRect:CGRectMake(CGRectGetMidX(ctrl.view.frame), CGRectGetMidY(ctrl.view.frame), 0, 20) inView:ctrl.view animated:YES];
     }
     
     if (wasOpened) {


### PR DESCRIPTION
add "open with" dialogue box in ipad.

This contains the fix for commit - https://github.com/kristikristo/react-native-file-opener/commit/89ba83ed63776d51030d8c6d423fa48b22cd5aed

CGRectMake in line 14 is not a proper return type. It is a function. hence it is removed and the menu containing the list of applications to open the file with is created manually in line 37.

fixes huangzuizui/react-native-file-opener#15