### PR TITLE
Fixed iOS build breaking

### DIFF
--- a/android/src/main/java/com/fileopener/FileOpenerPackage.java
+++ b/android/src/main/java/com/fileopener/FileOpenerPackage.java
@@ -1,7 +1,6 @@
 package com.fileopener;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -16,11 +15,6 @@ public class FileOpenerPackage implements ReactPackage {
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     //Registering the module.
     return Arrays.<NativeModule>asList(new FileOpener(reactContext));
-  }
-
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
   }
 
   @Override

--- a/ios/RNFileOpener/RNFileOpener.h
+++ b/ios/RNFileOpener/RNFileOpener.h
@@ -1,5 +1,5 @@
-#import "RCTBridgeModule.h"
-#import "RCTBridge.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTBridge.h>
 
 @import UIKit;
 

--- a/ios/RNFileOpener/RNFileOpener.m
+++ b/ios/RNFileOpener/RNFileOpener.m
@@ -11,7 +11,7 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMine fromRect:(CGRectMake)rect
+RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMine
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -34,7 +34,7 @@ RCT_REMAP_METHOD(open, filePath:(NSString *)filePath fileMine:(NSString *)fileMi
         
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
     {
-        wasOpened = [self.FileOpener presentOptionsMenuFromRect:rect inView:ctrl.view animated:YES];
+        wasOpened = [self.FileOpener presentOptionsMenuFromRect:CGRectMake(CGRectGetMidX(ctrl.view.frame), CGRectGetMidY(ctrl.view.frame), 0, 20) inView:ctrl.view animated:YES];
     }
     
     if (wasOpened) {


### PR DESCRIPTION
Updated `FileOpenerPackage.java` to no longer override the deprecated `createJSModules` method, fixed broken React imports in `RNFileOpener.h` and fixed `CGRectMake` return type.