### PR TITLE
error: redefinition of 'RCTMethodInfo' Fixed

### DIFF
--- a/ios/RNFileOpener/RNFileOpener.h
+++ b/ios/RNFileOpener/RNFileOpener.h
@@ -1,5 +1,9 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
-#import "RCTBridge.h"
+#endif
+#import <React/RCTBridge.h>
 
 @import UIKit;
 


### PR DESCRIPTION
fix for error: redefinition of 'RCTMethodInfo' typedef struct RCTMethodInfo